### PR TITLE
Remote http calls should return http exceptions if failed

### DIFF
--- a/src/Wdata.Lib/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Wdata.Lib/Extensions/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ public static class ServiceCollectionExtensions
             var localSource = config.GetLocalSource() 
                 ?? throw new InvalidOperationException("Local source configuration is missing");
 
-            return new WebsiteLocalSource(config.GetLocalSource()!.BasePath);
+            return new WebsiteLocalSource(localSource!.BasePath);
         });
 
         return services;

--- a/src/Wdata.Lib/Sources/WebsiteRemoteSource.cs
+++ b/src/Wdata.Lib/Sources/WebsiteRemoteSource.cs
@@ -42,6 +42,8 @@ public class WebsiteRemoteSource : IWebsiteDataSource
             : $"{_baseUrl.TrimEnd('/')}/{path.TrimStart('/')}";
         
         using var response = await _httpClient.GetAsync(url, cancel);
+        response.EnsureSuccessStatusCode();
+        
         return await response.Content.ReadAsStringAsync(cancel);
     }
 }

--- a/test/Wdata.Tests/IntegrationTests/WebsiteDataServiceTestsHappyFlow.cs
+++ b/test/Wdata.Tests/IntegrationTests/WebsiteDataServiceTestsHappyFlow.cs
@@ -7,7 +7,7 @@ using Wdata.Extensions;
 
 namespace Wdata.Tests.IntegrationTests;
 
-public class WebsiteDataServiceTests
+public partial class WebsiteDataServiceTests
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly IWebsiteDataService _websiteDataService;

--- a/test/Wdata.Tests/IntegrationTests/WebsiteDataServiceTestsUnhappyFlow.cs
+++ b/test/Wdata.Tests/IntegrationTests/WebsiteDataServiceTestsUnhappyFlow.cs
@@ -1,0 +1,12 @@
+namespace Wdata.Tests.IntegrationTests;
+
+public partial class WebsiteDataServiceTests
+{
+
+    [Fact]
+    public async Task Get_non_existing_remote_data_should_throw_exception()
+    {
+        await Assert.ThrowsAsync<HttpRequestException>(async () =>
+            await _websiteDataService.GetWebsiteDataAsync("remote", "test/website-data1.json"));
+    }
+}


### PR DESCRIPTION
- Add EnsureSuccessStatusCode for remote Http calls
- Add Unhappy flow test when getting non-existing remote resources